### PR TITLE
Doctrine - $reportFieldsWhereDeclared argument is no longer supported

### DIFF
--- a/src/RankyMediaBundle.php
+++ b/src/RankyMediaBundle.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Ranky\MediaBundle;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Ranky\MediaBundle\Infrastructure\DependencyInjection\MediaBundleExtension;
 use Ranky\MediaBundle\Infrastructure\DependencyInjection\MediaCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,12 +23,9 @@ class RankyMediaBundle extends Bundle
         parent::build($container);
         $container->addCompilerPass(new MediaCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         if (\class_exists('Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass')) {
-            $container->addCompilerPass(
-                DoctrineOrmMappingsPass::createAttributeMappingDriver(
-                    namespaces: ['Ranky\MediaBundle\Domain'],
-                    directories: [\dirname(__DIR__).'/src/Domain'],
-                )
-            );
+            $driver = new Definition(AttributeDriver::class, [[\dirname(__DIR__).'/src/Domain']]);
+            $compilerPass = new DoctrineOrmMappingsPass($driver, ['Ranky\MediaBundle\Domain'], []);
+            $container->addCompilerPass($compilerPass);
         }
     }
 


### PR DESCRIPTION
fix `The $reportFieldsWhereDeclared argument is no longer supported, make sure to omit it when calling Doctrine\ORM\Mapping\Driver\AttributeDriver::__construct.`